### PR TITLE
PrivateRoute wrapper + Profile Picture Feature

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2349,6 +2349,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "attr-accept": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
+      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+    },
     "autoprefixer": {
       "version": "9.8.6",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
@@ -5721,6 +5726,21 @@
       "requires": {
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0"
+      }
+    },
+    "file-selector": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.3.tgz",
+      "integrity": "sha512-d+hc9ctodLSVG55V2V5I4/eJBEr2p2na/kDN46Ty7PBhdp/Q5NmeQTXKa1Hx3AcIL1lgSFKZI0ve/v5ZXGCDkQ==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "filesize": {
@@ -10729,6 +10749,16 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-dropzone": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-11.2.4.tgz",
+      "integrity": "sha512-EGSvK2CxFTuc28WxwuJCICyuYFX8b+sRumwU6Bs6sTbElV2HtQkT0d6C+HEee6XfbjiLIZ+Th9uji27rvo2wGw==",
+      "requires": {
+        "attr-accept": "^2.2.1",
+        "file-selector": "^0.2.2",
+        "prop-types": "^15.7.2"
       }
     },
     "react-error-overlay": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1413,6 +1413,14 @@
         }
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/lab": {
       "version": "4.0.0-alpha.56",
       "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
@@ -1435,14 +1443,6 @@
             "react-is": "^16.8.0"
           }
         }
-      }
-    },
-    "@material-ui/icons": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
-      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
       }
     },
     "@material-ui/styles": {
@@ -5792,6 +5792,21 @@
       "requires": {
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0"
+      }
+    },
+    "file-selector": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.2.3.tgz",
+      "integrity": "sha512-d+hc9ctodLSVG55V2V5I4/eJBEr2p2na/kDN46Ty7PBhdp/Q5NmeQTXKa1Hx3AcIL1lgSFKZI0ve/v5ZXGCDkQ==",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
       }
     },
     "file-uri-to-path": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "axios": "^0.21.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3"
   },

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,8 @@ import { BrowserRouter, Route, Redirect, Switch } from "react-router-dom";
 
 import { theme } from "./themes/theme";
 
+import PrivateRoute from "./components/PrivateRoute";
+
 import Navbar from "./pages/Navbar";
 import Signup from "./pages/Signup";
 import Login from "./pages/Login";
@@ -22,7 +24,7 @@ function App() {
           <Redirect exact from="/" to="/signup" />
           <Route path="/signup" component={Signup} />
           <Route path="/login" component={Login} />
-          <Route path="/profile" component={Profile} />
+          <PrivateRoute path="/profile" component={Profile} />
         </Switch>
       </BrowserRouter>
     </MuiThemeProvider>

--- a/client/src/components/PrivateRoute.js
+++ b/client/src/components/PrivateRoute.js
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from "react";
+import { Route, Redirect } from "react-router-dom";
+
+const axios = require("axios");
+
+const PrivateRoute = ({ component: Component, ...rest }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    axios
+      .get("/profile")
+      .then((res) => {
+        setIsAuthenticated(true);
+      })
+      .catch((err) => {})
+      .finally(() => setIsLoaded(true));
+  }, [isAuthenticated]);
+
+  if (!isLoaded) return <></>;
+
+  return (
+    <Route
+      {...rest}
+      render={(props) =>
+        !isAuthenticated ? <Redirect to="/login" /> : <Component {...props} />
+      }
+    />
+  );
+};
+
+export default PrivateRoute;

--- a/client/src/components/uploadImage.js
+++ b/client/src/components/uploadImage.js
@@ -6,30 +6,33 @@ import {
   Card,
   CardActionArea,
   CardMedia,
-  CircularProgress,
+  Tooltip,
+  Avatar,
 } from "@material-ui/core";
 
 const axios = require("axios");
 
-const useStyles = makeStyles({
-  root: {
-    maxWidth: 345,
+const useStyles = makeStyles((theme) => ({
+  card: {
+    width: "200px",
+    margin: "10px auto 0",
+    padding: "10px 0",
   },
-  media: {
-    display: "block",
-    marginLeft: "auto",
-    marginRight: "auto",
-    height: "180px",
-    padding: "10px",
-    border: "1px solid black",
+  avatar: {
+    margin: "auto",
+    height: "170px",
+    width: "170px",
+    border: "5px solid rgba(0, 0, 0, 0.5)",
+    fontSize: "100px",
   },
-});
+}));
 
 const UploadImage = (props) => {
   const classes = useStyles();
 
   const [values, setValues] = useState({
     id: "",
+    name: "",
     imageUrl: "",
   });
 
@@ -37,6 +40,7 @@ const UploadImage = (props) => {
     axios.get("/account").then((res) => {
       setValues({
         id: res.data._id,
+        name: res.data.name,
         imageUrl: res.data.imageUrl,
       });
     });
@@ -52,7 +56,6 @@ const UploadImage = (props) => {
       .then((res) => {
         // TODO: Reload the image without having to refresh the entire page
         setValues({ id: values["id"], imageUrl: res.data.imageUrl });
-        console.log("Image URL successfully set: " + res.data.imageUrl);
         window.location.reload();
       })
       .catch((err) => {});
@@ -76,27 +79,21 @@ const UploadImage = (props) => {
           fileRejections.length > 0 && fileRejections[0].size > 5242880;
         return (
           <div {...getRootProps()}>
-            <Card>
-              <CardActionArea>
-                <CardMedia>
-                  <img
-                    src={values["imageUrl"]}
-                    alt="Profile Picture"
-                    className={classes.media}
-                  />
-                </CardMedia>
-                <input {...getInputProps()} />
-                {!isDragActive &&
-                  "Click here or drop a valid image file to set as your profile picture."}
-                {isDragActive && !isDragReject && "Valid file"}
-                {isDragReject && "File type not accepted"}
-                {isFileTooLarge && (
-                  <div className="text-danger mt-2">
-                    File is too large (Please select a file under 5 MB).
-                  </div>
-                )}
-              </CardActionArea>
-            </Card>
+            <Tooltip title="Click or drag image here to set as profile picture">
+              <Card className={classes.card}>
+                <CardActionArea>
+                  <CardMedia>
+                    <Avatar src={values["imageUrl"]} className={classes.avatar}>
+                      {values["name"] ? values["name"][0] : ""}
+                    </Avatar>
+                  </CardMedia>
+                  <input {...getInputProps()} />
+                  {isDragReject && "File type not accepted"}
+                  {isFileTooLarge &&
+                    "File is too large (Please select a file <= 5 MB)."}
+                </CardActionArea>
+              </Card>
+            </Tooltip>
           </div>
         );
       }}

--- a/client/src/components/uploadImage.js
+++ b/client/src/components/uploadImage.js
@@ -16,24 +16,44 @@ const useStyles = makeStyles({
     maxWidth: 345,
   },
   media: {
-    height: 140,
+    display: "block",
+    marginLeft: "auto",
+    marginRight: "auto",
+    height: "180px",
+    padding: "10px",
+    border: "1px solid black",
   },
 });
 
 const UploadImage = (props) => {
   const classes = useStyles();
 
-  const [imageUrl, setImageUrl] = useState(props.values["imageUrl"]);
+  const [values, setValues] = useState({
+    id: "",
+    imageUrl: "",
+  });
+
+  useEffect(() => {
+    axios.get("/account").then((res) => {
+      setValues({
+        id: res.data._id,
+        imageUrl: res.data.imageUrl,
+      });
+    });
+  }, []);
 
   const onDropAccepted = (acceptedFiles) => {
     let data = new FormData();
-    data.append("id", props.values["id"]);
+    data.append("id", values["id"]);
     data.append("image", acceptedFiles[0]);
 
     axios
       .post("/uploadImage", data)
       .then((res) => {
-        setImageUrl(res.data.imageUrl);
+        // TODO: Reload the image without having to refresh the entire page
+        setValues({ id: values["id"], imageUrl: res.data.imageUrl });
+        console.log("Image URL successfully set: " + res.data.imageUrl);
+        window.location.reload();
       })
       .catch((err) => {});
   };
@@ -58,11 +78,13 @@ const UploadImage = (props) => {
           <div {...getRootProps()}>
             <Card>
               <CardActionArea>
-                <CardMedia
-                  className={classes.media}
-                  image={imageUrl !== "" ? imageUrl : ""}
-                  title="Profile Picture"
-                ></CardMedia>
+                <CardMedia>
+                  <img
+                    src={values["imageUrl"]}
+                    alt="Profile Picture"
+                    className={classes.media}
+                  />
+                </CardMedia>
                 <input {...getInputProps()} />
                 {!isDragActive &&
                   "Click here or drop a valid image file to set as your profile picture."}

--- a/client/src/components/uploadImage.js
+++ b/client/src/components/uploadImage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Dropzone from "react-dropzone";
 
@@ -30,33 +30,30 @@ const useStyles = makeStyles((theme) => ({
 const UploadImage = (props) => {
   const classes = useStyles();
 
-  const [values, setValues] = useState({
-    id: "",
-    name: "",
-    imageUrl: "",
-  });
-
-  useEffect(() => {
-    axios.get("/account").then((res) => {
-      setValues({
-        id: res.data._id,
-        name: res.data.name,
-        imageUrl: res.data.imageUrl,
-      });
-    });
-  }, []);
-
   const onDropAccepted = (acceptedFiles) => {
     let data = new FormData();
-    data.append("id", values["id"]);
+    data.append("id", props.values["id"]);
     data.append("image", acceptedFiles[0]);
 
     axios
       .post("/uploadImage", data)
       .then((res) => {
         // TODO: Reload the image without having to refresh the entire page
-        setValues({ id: values["id"], imageUrl: res.data.imageUrl });
-        window.location.reload();
+        props.setValues({
+          id: props.values["id"],
+          name: props.values["name"],
+          email: props.values["email"],
+          imageUrl: "",
+        });
+
+        props.setValues({
+          id: props.values["id"],
+          name: props.values["name"],
+          email: props.values["email"],
+          imageUrl: res.data.imageUrl,
+        });
+
+        // window.location.reload();
       })
       .catch((err) => {});
   };
@@ -83,8 +80,11 @@ const UploadImage = (props) => {
               <Card className={classes.card}>
                 <CardActionArea>
                   <CardMedia>
-                    <Avatar src={values["imageUrl"]} className={classes.avatar}>
-                      {values["name"] ? values["name"][0] : ""}
+                    <Avatar
+                      src={`${props.values["imageUrl"]}?${Date.now()}` || ""}
+                      className={classes.avatar}
+                    >
+                      {props.values["name"] ? props.values["name"][0] : ""}
                     </Avatar>
                   </CardMedia>
                   <input {...getInputProps()} />

--- a/client/src/components/uploadImage.js
+++ b/client/src/components/uploadImage.js
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Dropzone from "react-dropzone";
+
+import {
+  Card,
+  CardActionArea,
+  CardMedia,
+  CircularProgress,
+} from "@material-ui/core";
+
+const axios = require("axios");
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 345,
+  },
+  media: {
+    height: 140,
+  },
+});
+
+const UploadImage = (props) => {
+  const classes = useStyles();
+
+  const [imageUrl, setImageUrl] = useState(props.values["imageUrl"]);
+
+  const onDropAccepted = (acceptedFiles) => {
+    let data = new FormData();
+    data.append("id", props.values["id"]);
+    data.append("image", acceptedFiles[0]);
+
+    axios
+      .post("/uploadImage", data)
+      .then((res) => {
+        setImageUrl(res.data.imageUrl);
+      })
+      .catch((err) => {});
+  };
+
+  return (
+    <Dropzone
+      onDropAccepted={onDropAccepted}
+      accept="image/*"
+      minSize={0}
+      maxSize={5242880}
+    >
+      {({
+        getRootProps,
+        getInputProps,
+        isDragActive,
+        isDragReject,
+        fileRejections,
+      }) => {
+        const isFileTooLarge =
+          fileRejections.length > 0 && fileRejections[0].size > 5242880;
+        return (
+          <div {...getRootProps()}>
+            <Card>
+              <CardActionArea>
+                <CardMedia
+                  className={classes.media}
+                  image={imageUrl !== "" ? imageUrl : ""}
+                  title="Profile Picture"
+                ></CardMedia>
+                <input {...getInputProps()} />
+                {!isDragActive &&
+                  "Click here or drop a valid image file to set as your profile picture."}
+                {isDragActive && !isDragReject && "Valid file"}
+                {isDragReject && "File type not accepted"}
+                {isFileTooLarge && (
+                  <div className="text-danger mt-2">
+                    File is too large (Please select a file under 5 MB).
+                  </div>
+                )}
+              </CardActionArea>
+            </Card>
+          </div>
+        );
+      }}
+    </Dropzone>
+  );
+};
+
+export default UploadImage;

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -75,11 +75,10 @@ const Login = () => {
     axios
       .post("/login", values)
       .then((res) => {
-        // TODO: Success logic
+        // If login is successful, redirect to profile page
         history.push("/profile");
       })
       .catch((err) => {
-        // TODO: Error logic
         setSnackBarMessage(err.response.data.errors);
         setSnackbarOpen(true);
       });

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -61,7 +61,7 @@ const Profile = () => {
       .get("/account")
       .then((res) => {
         setValues({
-          id: res.data.id,
+          id: res.data._id,
           name: res.data.name,
           email: res.data.email,
           imageUrl: res.data.imageUrl,
@@ -98,7 +98,7 @@ const Profile = () => {
                   disabled
                 />
                 <Typography variant="subtitle1">Profile Picture:</Typography>
-                <UploadImage values={values} />
+                <UploadImage values={values} setValues={setValues} />
                 <br />
                 <Button
                   variant="contained"

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 
 import { Button, TextField, Typography, Container } from "@material-ui/core";
 
-import UploadImage from "../components/uploadImage";
+import UploadImage from "../components/UploadImage";
 
 const axios = require("axios");
 

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -4,7 +4,7 @@ import { useHistory } from "react-router-dom";
 
 import { Button, TextField, Typography, Container } from "@material-ui/core";
 
-import UploadImage from "../components/UploadImage";
+import UploadImage from "../components/uploadImage";
 
 const axios = require("axios");
 
@@ -58,7 +58,7 @@ const Profile = () => {
 
   useEffect(() => {
     axios
-      .get("/profile")
+      .get("/account")
       .then((res) => {
         setValues({
           id: res.data.id,

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -1,15 +1,10 @@
 import React, { useState, useEffect } from "react";
+import { makeStyles } from "@material-ui/core/styles";
 import { useHistory } from "react-router-dom";
 
-import {
-  Button,
-  TextField,
-  Link,
-  Typography,
-  Container,
-  Snackbar,
-} from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
+import { Button, TextField, Typography, Container } from "@material-ui/core";
+
+import UploadImage from "../components/uploadImage";
 
 const axios = require("axios");
 
@@ -47,8 +42,10 @@ const Profile = () => {
   let history = useHistory();
 
   const [values, setValues] = useState({
+    id: "",
     name: "",
     email: "",
+    imageUrl: "",
   });
 
   const logout = () => {
@@ -64,8 +61,10 @@ const Profile = () => {
       .get("/profile")
       .then((res) => {
         setValues({
+          id: res.data.id,
           name: res.data.name,
           email: res.data.email,
+          imageUrl: res.data.imageUrl,
         });
       })
       .catch((err) => {
@@ -98,6 +97,8 @@ const Profile = () => {
                   value={values["email"]}
                   disabled
                 />
+                <Typography variant="subtitle1">Profile Picture:</Typography>
+                <UploadImage values={values} />
                 <br />
                 <Button
                   variant="contained"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,475 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "bson": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "kareem": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "mongodb": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.10.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.10.13.tgz",
+      "integrity": "sha512-lvZzTj449sVWijY76StOuTKt5oP5kyy70VdM3DMgPpKNqZfkAseHxekmqBbd9YQQDVIgrIYDar9vSlxKqc75MQ==",
+      "requires": {
+        "bson": "^1.1.4",
+        "kareem": "2.3.1",
+        "mongodb": "3.6.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.7.0",
+        "mquery": "3.2.2",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mpath": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+      "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg=="
+    },
+    "mquery": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+      "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    }
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,7 @@ const loginRouter = require("./routes/login");
 const logoutRouter = require("./routes/logout");
 const profileRouter = require("./routes/profile");
 const uploadImageRouter = require("./routes/uploadImage");
+const accountRouter = require("./routes/account");
 
 const { json, urlencoded } = express;
 
@@ -27,13 +28,14 @@ app.use(express.static(join(__dirname, "public")));
 
 app.use("/", indexRouter);
 app.use("/ping", pingRouter);
-app.use('/game', gameRouter);
+app.use("/game", gameRouter);
 
 app.use("/register", registerRouter);
 app.use("/login", loginRouter);
 app.use("/logout", logoutRouter);
 app.use("/profile", profileRouter);
 app.use("/uploadImage", uploadImageRouter);
+app.use("/account", accountRouter);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => next(createError(404)));

--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,7 @@ const registerRouter = require("./routes/register");
 const loginRouter = require("./routes/login");
 const logoutRouter = require("./routes/logout");
 const profileRouter = require("./routes/profile");
+const uploadImageRouter = require("./routes/uploadImage");
 
 const { json, urlencoded } = express;
 
@@ -51,6 +52,7 @@ app.use("/register", registerRouter);
 app.use("/login", loginRouter);
 app.use("/logout", logoutRouter);
 app.use("/profile", profileRouter);
+app.use("/uploadImage", uploadImageRouter);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => next(createError(404)));

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -15,6 +15,10 @@ let userSchema = new Schema(
       type: String,
       required: true,
     },
+    // Profile Picture
+    imageUrl: {
+      type: String,
+    },
   },
   {
     timestamps: true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -92,6 +92,11 @@
         }
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -152,6 +157,22 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "aws-sdk": {
+      "version": "2.792.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.792.0.tgz",
+      "integrity": "sha512-h7oSlrCDtZkW5qNw/idKmMjjNJaaPlXFY+NbqtaTjejpCyVuIonUmFvm8GW16V58Avj/hujJfhpX9q0BMCg+VQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
     },
     "axios": {
       "version": "0.21.0",
@@ -215,6 +236,11 @@
           }
         }
       }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "basic-auth": {
       "version": "2.0.1",
@@ -355,10 +381,57 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
       "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -543,6 +616,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "configstore": {
       "version": "3.1.2",
@@ -734,6 +818,38 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -836,6 +952,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
       "version": "0.7.0",
@@ -1046,6 +1167,11 @@
           }
         }
       }
+    },
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1774,6 +1900,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
+    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -1792,6 +1923,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -2040,6 +2176,14 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
+    },
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
@@ -2068,6 +2212,11 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -2365,7 +2514,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2373,8 +2521,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -2526,6 +2673,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.1.1",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
+    },
+    "multer-s3": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/multer-s3/-/multer-s3-2.9.0.tgz",
+      "integrity": "sha512-qLF8pCD5HhXLLd954q49B63x3bk6Fe0jqD3eM0FVcGtqhiSVuTrchEDAo0mnO5pc34cMuX/CVCCbPkGTjX2xUA==",
+      "requires": {
+        "file-type": "^3.3.0",
+        "is-svg": "^2.1.0",
+        "run-parallel": "^1.1.6"
+      }
     },
     "nan": {
       "version": "2.14.0",
@@ -2928,10 +3100,20 @@
         "once": "^1.3.1"
       }
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -3090,6 +3272,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
+    "run-parallel": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -3116,6 +3303,11 @@
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "5.7.0",
@@ -3387,6 +3579,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3544,6 +3741,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
     "undefsafe": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
@@ -3644,6 +3846,15 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -3666,6 +3877,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vary": {
       "version": "1.1.2",
@@ -3770,6 +3986,25 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -172,6 +172,13 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "axios": {
@@ -236,6 +243,11 @@
           }
         }
       }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "test": "NODE_ENV=test ./node_modules/.bin/mocha --exit --timeout 30000"
   },
   "dependencies": {
+    "aws-sdk": "^2.792.0",
     "axios": "^0.21.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
@@ -21,7 +22,10 @@
     "mongodb": "^3.6.3",
     "mongoose": "^5.10.13",
     "morgan": "~1.9.1",
-    "nodemon": "^1.19.1"
+    "multer": "^1.4.2",
+    "multer-s3": "^2.9.0",
+    "nodemon": "^1.19.1",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/server/routes/account.js
+++ b/server/routes/account.js
@@ -1,16 +1,23 @@
-// Check to see if a user is logged in and authenticated
-// This route only returns cookie info
+// Get account information from MongoDB
 
 const express = require("express");
 const router = express.Router();
 
 const { authenticateToken } = require("../controllers/auth");
 
+const User = require("../models/User");
+
 router.get("/", authenticateToken, (req, res) => {
   let user = req.user;
 
   if (user) {
-    res.status(200).json(user);
+    User.findById(user.id)
+      .then((user) => {
+        return res.status(200).json(user);
+      })
+      .catch((err) => {
+        res.status(400).json(err);
+      });
   } else {
     res.sendStatus(403);
   }

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -25,15 +25,16 @@ router.post("/", function (req, res, next) {
             if (!isMatch) {
               return res.status(400).json({ errors: "Invalid credentials" });
             }
-
+            
             const payload = {
               id: user._id,
               name: user.name,
               email: user.email,
+              imageUrl: user.imageUrl,
             };
 
             // Correct credentials have been provided; create JWT
-            const access_token = createAccessToken(payload, "10m");
+            const access_token = createAccessToken(payload, "30m");
 
             jwt.verify(
               access_token,

--- a/server/routes/register.js
+++ b/server/routes/register.js
@@ -53,6 +53,7 @@ router.post("/", function (req, res, next) {
           name: name,
           email: email,
           password: password,
+          imageUrl: "",
         });
 
         bcrypt.hash(password, 10).then((hash) => {

--- a/server/routes/uploadImage.js
+++ b/server/routes/uploadImage.js
@@ -1,0 +1,25 @@
+const express = require("express");
+const router = express.Router();
+
+const upload = require("../services/uploadImage");
+
+const User = require("../models/User");
+
+router.post("/", (req, res) => {
+  // ISSUE: Cannot read req values here, but can read them inside the Multer code block
+  // EXPECTED RESULT: Check user exists in MongoDB database first, then run Multer
+
+  upload.single("image")(req, res, (err) => {
+    if (err) return res.status(422).json(err);
+    User.findById(req.body.id).then((user) => {
+      if (!user) return res.sendStatus(404);
+
+      user.imageUrl = req.file.location;
+      user.save();
+
+      return res.status(200).json({ imageUrl: req.file.location });
+    });
+  });
+});
+
+module.exports = router;

--- a/server/services/uploadImage.js
+++ b/server/services/uploadImage.js
@@ -1,0 +1,43 @@
+const aws = require("aws-sdk");
+const multer = require("multer");
+const multerS3 = require("multer-s3");
+const path = require("path");
+
+aws.config.update({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  region: process.env.AWS_REGION,
+});
+
+const s3 = new aws.S3();
+
+// Set filter to only accept image formats
+const fileFilter = (req, file, cb) => {
+  if (file.mimetype.includes("image/")) {
+    cb(null, true);
+  } else {
+    cb(new Error("Invalid Mime Type; Please upload an image file"), false);
+  }
+};
+
+// Configure multer storage for AWS S3
+const storage = multerS3({
+  s3: s3,
+  bucket: "teamfruitloops",
+  acl: "public-read",
+  contentType: multerS3.AUTO_CONTENT_TYPE,
+  metadata: function (req, file, cb) {
+    cb(null, { fieldName: file.fieldname });
+  },
+  key: function (req, file, cb) {
+    // Set name of file to equal user's object ID
+    cb(null, req.body.id);
+  },
+});
+
+const upload = multer({
+  fileFilter: fileFilter,
+  storage: storage,
+});
+
+module.exports = upload;

--- a/server/utils/account.js
+++ b/server/utils/account.js
@@ -1,0 +1,7 @@
+const User = require("../models/User");
+
+exports.getCurrentUser = (id) => {
+  User.findById(id).then((user) => {
+    return user;
+  });
+};

--- a/server/utils/account.js
+++ b/server/utils/account.js
@@ -1,7 +1,0 @@
-const User = require("../models/User");
-
-exports.getCurrentUser = (id) => {
-  User.findById(id).then((user) => {
-    return user;
-  });
-};


### PR DESCRIPTION
This branch currently has a React-DropZone component where you can upload images to serve as profile pictures; the image is saved with filename equal to the User's MongoDB ID.

There are some issues with properly rendering the image whenever it is changed (notwithstanding some minor CSS tweaks required), but I am still looking at it. The NavBar will also need to be updated to include the Name/Profile Picture visible on top-right.